### PR TITLE
Add option to sort by damage to results list

### DIFF
--- a/src/lib/components/DamageSortPopover.svelte
+++ b/src/lib/components/DamageSortPopover.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+	import { Popover, Separator } from "bits-ui";
+	import { appWindow } from "$lib/stores/appWindow.svelte";
+	import type { ResultList } from "$lib/types/resultList.svelte";
+
+	type Props = {
+		resultList: ResultList;
+	};
+
+	let { resultList }: Props = $props();
+
+	let open = $state(false);
+	let order = $state("asc");
+	let type = $state("damageS");
+	let includeOV = $state(false);
+
+	function clearSort() {
+		open = false;
+		resultList.sort = { key: "", order: "asc", extra: "" };
+	}
+
+	function setSort() {
+		open = false;
+		resultList.sort = { key: "damage", order, extra: { type, includeOV } };
+	}
+</script>
+
+<Popover.Root bind:open>
+	<Popover.Trigger class={appWindow.isMobile ? "sort-header-button-mobile" : "sort-header-button"}>
+		{#if appWindow.isMobile}
+			<p>DMG</p>
+		{:else}
+			<p>
+				<span class:span-highlight={resultList.sort.extra?.type == "damageTotal"}>DMG</span>
+				<span class:span-highlight={resultList.sort.extra?.type == "damageS" || resultList.sort.extra?.type == "damageTotal"}>S</span>/<span
+					class:span-highlight={resultList.sort.extra?.type == "damageM" || resultList.sort.extra?.type == "damageTotal"}>M</span
+				>/<span class:span-highlight={resultList.sort.extra?.type == "damageL" || resultList.sort.extra?.type == "damageTotal"}>L</span> -
+				<span class:span-highlight={resultList.sort.extra?.type == "overheat" || resultList.sort.extra?.includeOV}>OV</span>
+			</p>
+		{/if}
+		{#if resultList.sort.key == "damage"}
+			<img class="sort-selected button-icon" src={resultList.sort.order == "asc" ? "/icons/sort-ascending.svg" : "/icons/sort-descending.svg"} alt="sort" />
+		{:else}
+			<img class="sort button-icon" src="/icons/sort.svg" alt="sort" />
+		{/if}</Popover.Trigger
+	>
+	<Popover.Content class="damage-sort-content">
+		<div class="damage-sort-content-container">
+			<label
+				>Sort by:
+				<select name="damage-sort-type" id="damage-sort-type" bind:value={type}>
+					<option value="damageS">Short</option>
+					<option value="damageM">Medium</option>
+					<option value="damageL">Long</option>
+					<option value="damageTotal">Total</option>
+					<option value="overheat">Overheat</option>
+				</select>
+			</label>
+			<label
+				>Order:
+				<select bind:value={order}>
+					<option value="asc">Ascending</option>
+					<option value="desc">Descending</option>
+				</select>
+			</label>
+			<label><input type="checkbox" name="damage-sort-include-ov" id="damage-sort-include-ov" bind:checked={includeOV} /> Include Overheat</label>
+			<Separator.Root decorative={true} class="muted-separator" />
+			<div class="space-between">
+				<button onclick={clearSort}>Clear</button>
+				<button onclick={setSort}>Sort</button>
+			</div>
+		</div>
+	</Popover.Content>
+</Popover.Root>
+
+<style>
+	:global(.damage-sort-content) {
+		z-index: 5;
+		padding: 16px;
+		background-color: var(--background);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+	}
+	:global(.damage-sort-content-container) {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	:global(.span-highlight) {
+		color: var(--primary);
+	}
+</style>

--- a/src/lib/components/Generic/Combobox.svelte
+++ b/src/lib/components/Generic/Combobox.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
 	import { Combobox, type WithoutChildrenOrChild, mergeProps } from "bits-ui";
-
-	export type ComboboxItem = { value: string; label: string };
+	import type { Item } from "./types";
 
 	type Props = Combobox.RootProps & {
-		items: ComboboxItem[];
+		items: Item[];
 		inputProps?: WithoutChildrenOrChild<Combobox.InputProps>;
 		contentProps?: WithoutChildrenOrChild<Combobox.ContentProps>;
 	};

--- a/src/lib/components/Generic/types.ts
+++ b/src/lib/components/Generic/types.ts
@@ -1,0 +1,5 @@
+export type Item = {
+	value: string;
+	label: string;
+	disabled?: boolean;
+};

--- a/src/lib/components/SearchParameters.svelte
+++ b/src/lib/components/SearchParameters.svelte
@@ -4,7 +4,8 @@
 	import { appWindow } from "$lib/stores/appWindow.svelte";
 	import { ResultList } from "$lib/types/resultList.svelte";
 	import { getContext, onMount } from "svelte";
-	import Combobox, { type ComboboxItem } from "./Generic/Combobox.svelte";
+	import Combobox from "./Generic/Combobox.svelte";
+	import type { Item } from "./Generic/types";
 	import type { List } from "../../routes/listbuilder/types/list.svelte";
 
 	const resultList: ResultList = getContext("resultList");
@@ -12,7 +13,7 @@
 
 	let showParameters = $state(false);
 
-	let allowedEras: ComboboxItem[] = eraLists
+	let allowedEras: Item[] = eraLists
 		.filter((era) => {
 			return era.id != 0;
 		})

--- a/src/lib/components/SearchResults.svelte
+++ b/src/lib/components/SearchResults.svelte
@@ -7,11 +7,28 @@
 	import { ResultList } from "$lib/types/resultList.svelte";
 	import { getContext } from "svelte";
 	import type { List } from "../../routes/listbuilder/types/list.svelte";
+	import DamageSortPopover from "./DamageSortPopover.svelte";
 
 	const list: List = getContext("list");
 	const resultList: ResultList = getContext("resultList");
 
-	let headers = $derived(appWindow.isMobile ? ["Type", "PV", "Move", "Health"] : ["Type", "PV", "Size", "Move", "TMM", "Health (A+S)"]);
+	let headers = $derived(
+		appWindow.isMobile
+			? [
+					{ label: "Type", key: "subtype" },
+					{ label: "PV", key: "pv" },
+					{ label: "Move", key: "move" },
+					{ label: "Health", key: "health" }
+				]
+			: [
+					{ label: "Type", key: "subtype" },
+					{ label: "PV", key: "pv" },
+					{ label: "Size", key: "size" },
+					{ label: "Move", key: "move" },
+					{ label: "TMM", key: "tmm" },
+					{ label: "Health (A+S)", key: "health" }
+				]
+	);
 
 	let listHeight = $state(500);
 	let listWidth = $state(0);
@@ -19,19 +36,15 @@
 	let availabilityDialog = $state<HTMLDialogElement>();
 	let availabilityResults = $state<any[]>([]);
 
-	function sort(event: Event) {
-		if (event.target instanceof HTMLElement) {
-			const target = event.currentTarget as HTMLElement;
-			const targetName = target.dataset.sort!;
-			if (resultList.sort.key != targetName) {
-				resultList.sort.key = targetName;
-				resultList.sort.order = "asc";
+	function sort(key: string) {
+		if (resultList.sort.key != key) {
+			resultList.sort.key = key;
+			resultList.sort.order = "asc";
+		} else {
+			if (resultList.sort.order == "asc") {
+				resultList.sort.order = "des";
 			} else {
-				if (resultList.sort.order == "asc") {
-					resultList.sort.order = "des";
-				} else {
-					resultList.sort.key = "";
-				}
+				resultList.sort.key = "";
 			}
 		}
 	}
@@ -54,7 +67,7 @@
 <div class="search-results">
 	<div class:result-list-header={!appWindow.isMobile} class:result-list-header-mobile={appWindow.isMobile}>
 		<div class:sort-header-button={!appWindow.isMobile} class:sort-header-button-mobile={appWindow.isMobile}></div>
-		<button class:sort-header-button={!appWindow.isMobile} class:sort-header-button-mobile={appWindow.isMobile} data-sort="name" onclick={sort} bind:clientWidth={listWidth}>
+		<button class:sort-header-button={!appWindow.isMobile} class:sort-header-button-mobile={appWindow.isMobile} onclick={() => sort("name")} bind:clientWidth={listWidth}>
 			{appWindow.isMobile ? `Name` : `Name - ${resultList.filteredList.length}/${resultList.availableList.length} results shown`}
 			{#if resultList.sort.key == "name"}
 				<img class="sort-selected button-icon" src={resultList.sort.order == "asc" ? "/icons/sort-ascending.svg" : "/icons/sort-descending.svg"} alt="sort" />
@@ -63,16 +76,17 @@
 			{/if}
 		</button>
 		{#each headers as header}
-			<button class:sort-header-button={!appWindow.isMobile} class:sort-header-button-mobile={appWindow.isMobile} data-sort={header.toLowerCase()} onclick={sort}>
-				{header}
-				{#if resultList.sort.key == header.toLowerCase()}
+			<button class:sort-header-button={!appWindow.isMobile} class:sort-header-button-mobile={appWindow.isMobile} onclick={() => sort(header.key)}>
+				{header.label}
+				{#if resultList.sort.key == header.key}
 					<img class="sort-selected button-icon" src={resultList.sort.order == "asc" ? "/icons/sort-ascending.svg" : "/icons/sort-descending.svg"} alt="sort" />
 				{:else}
 					<img class="sort button-icon" src="/icons/sort.svg" alt="sort" />
 				{/if}
 			</button>
 		{/each}
-		<button class:sort-header-button={!appWindow.isMobile} class:sort-header-button-mobile={appWindow.isMobile}> {appWindow.isMobile ? `DMG` : `DMG S/M/L-OV`}</button>
+		<!-- <button class:sort-header-button={!appWindow.isMobile} class:sort-header-button-mobile={appWindow.isMobile}> </button> -->
+		<DamageSortPopover {resultList}></DamageSortPopover>
 	</div>
 	{#await resultList.status}
 		<div class="loading-message">Loading units. Please wait ...</div>
@@ -200,8 +214,7 @@
 		display: flex;
 		font-size: x-large;
 	}
-	.sort-header-button,
-	.sort-header-button-mobile {
+	:global(.sort-header-button, .sort-header-button-mobile) {
 		background-color: var(--card);
 		display: flex;
 		align-items: center;
@@ -213,16 +226,17 @@
 		border: 1px solid var(--border);
 		border-radius: 0%;
 	}
-	.sort-header-button-mobile {
+	:global(.sort-header-button-mobile) {
 		display: flex;
 		flex-direction: column;
-		img {
-			width: 10px;
-			height: 10px;
-		}
 		gap: 0px;
 	}
-	.sort {
+	:global(.sort-header-button-mobile img) {
+		width: 10px;
+		height: 10px;
+	}
+
+	:global(.sort) {
 		filter: var(--muted-filter);
 	}
 	:global(.sort-selected) {

--- a/src/lib/types/resultList.svelte.ts
+++ b/src/lib/types/resultList.svelte.ts
@@ -65,7 +65,7 @@ export class ResultList {
 
 	filters = $state<Filter[]>(filtersImport);
 	additionalFilters = $state<Filter[]>(additionalFiltersImport);
-	sort = $state({ key: "", order: "asc" });
+	sort = $state<{ key: string; order: string; extra?: any }>({ key: "", order: "asc" });
 	filteredList = $derived.by(() => this.filterList());
 
 	status = $state();
@@ -327,9 +327,18 @@ export class ResultList {
 					} else {
 						second = b.move[0].speed;
 					}
-				} else if (this.sort.key == "health (a+s)") {
-					first = a.health;
-					second = b.health;
+				} else if (this.sort.key == "damage") {
+					if (this.sort.extra.type == "damageTotal") {
+						first = (a.damageS ?? 0) + (a.damageM ?? 0) + (a.damageL ?? 0);
+						second = (b.damageS ?? 0) + (b.damageM ?? 0) + (b.damageL ?? 0);
+					} else {
+						first = a[this.sort.extra.type];
+						second = b[this.sort.extra.type];
+					}
+					if (this.sort.extra.includeOV) {
+						first += a.overheat ?? 0;
+						second += b.overheat ?? 0;
+					}
 				} else {
 					first = a[this.sort.key];
 					second = b[this.sort.key];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -246,4 +246,8 @@
 		padding: 0;
 		margin: 0;
 	}
+	:global(.muted-separator) {
+		border: 1px solid var(--border);
+		margin: 4px 0px;
+	}
 </style>

--- a/static/changelog.json
+++ b/static/changelog.json
@@ -1,14 +1,20 @@
 [
 	{
 		"date": "2-22-25",
-		"updates": { "Unit Search / Listbuilder": ["Added ability to select multiple eras and factions", "Added checkbox to remove automatic general list from search results"] }
+		"updates": {
+			"Unit Search / List Builder": [
+				"Added ability to select multiple eras and factions",
+				"Added checkbox to remove automatic general list from search results",
+				"Add sorting by damage to search results"
+			]
+		}
 	},
 	{
 		"date": "2-16-25",
 		"notice": "New year, new stuff. Getting back to working on this site in my free time. Did a bunch of backend work to make further work easier and improve site performance. I have some big plans for the site this year, so stay tuned.",
 		"updates": {
 			"Site-wide": ["Added some visual effects to make the site feel nicer"],
-			"Listbuilder": [
+			"List Builder": [
 				"Fixed export functions for Jeff's tools, and added the ability to export specific formations and sublists.",
 				"Rebuilt how data is stored in the backend to prevent some errors that would occasionally crash the page.",
 				"Various tweaks/improvements that should hopefully improve the user experience."
@@ -18,7 +24,7 @@
 	{
 		"date": "12-20-24",
 		"updates": {
-			"Listbuilder": [
+			"List Builder": [
 				"Rebuilt PDF generation since it was originally put together without formations and ability references in mind. Previous version would cause units to start stacking on top of each other instead of creating a new page if too many units were added. New pdf generation should scale up without issues."
 			]
 		}
@@ -26,13 +32,13 @@
 	{
 		"date": "11-20-24",
 		"updates": {
-			"Unit Search / Listbuilder": ["Fixed dropdown overlay issues", "Fixed formation types not saving when changed"]
+			"Unit Search / List Builder": ["Fixed dropdown overlay issues", "Fixed formation types not saving when changed"]
 		}
 	},
 	{
 		"date": "11-19-24",
 		"updates": {
-			"Unit Search / Listbuilder": ["Added filter for movement type", "Fixed bug where max movement filter didn't work"],
+			"Unit Search / List Builder": ["Added filter for movement type", "Fixed bug where max movement filter didn't work"],
 			"List Builder": [
 				"Bumped up card sizes on printed list to match standard sleeve size. (previously it generated at the correct size on the pdf, but would scale down on most printers due to margins)"
 			]
@@ -67,7 +73,7 @@
 	{
 		"date": "7-7-24",
 		"updates": {
-			"Unit Search / Listbuilder": ["Fixed spacing issues with longer unit names.", "Added unit availability button to see what eras/factions have access to a unit."]
+			"Unit Search / List Builder": ["Fixed spacing issues with longer unit names.", "Added unit availability button to see what eras/factions have access to a unit."]
 		}
 	},
 	{
@@ -91,14 +97,14 @@
 	{
 		"date": "6-18-24",
 		"updates": {
-			"Listbuilder": ["Added Drag and drop functionality", "Added formations to unit list", "Changed shareable list code format"]
+			"List Builder": ["Added Drag and drop functionality", "Added formations to unit list", "Changed shareable list code format"]
 		}
 	},
 	{
 		"date": "6-1-24",
 		"notice": "Kind of stopped keeping this list up to date. These are the major changes implemented over the last month and a half.",
 		"updates": {
-			"Listbuilder": ["Combined generic and 350 list builders into one with a rules selector."],
+			"List Builder": ["Combined generic and 350 list builders into one with a rules selector."],
 			"Unit Search": ["Added a unit lookup separate from the list builder"],
 			"Tournament Dashboard": ["Created tournament dashboard and list validator"]
 		}
@@ -136,7 +142,7 @@
 		"date": "3-20-24",
 		"updates": {
 			"List Builder": [
-				" Add caching for faction lists. Should reduce the number of times the MUL is hit when searching for same faction in a day and add ability for listbuilder to still function when MUL is down."
+				" Add caching for faction lists. Should reduce the number of times the MUL is hit when searching for same faction in a day and add ability for List Builder to still function when MUL is down."
 			]
 		}
 	},


### PR DESCRIPTION
<!--
For Work In Progress Pull Requests, please use the Draft PR feature.
See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

**Type**  
What type of pull request is this? (e.g., Bug fix, Feature, Refactor, etc.)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Other (please describe):

**Description**  
Added sorting by damage key. Instead of using existing sort function, created a popover that allows for selecting what to sort by, the order to sort in, and the whether to add overheat or not.

**Related Issue**  
Addresses #61 

**How Has This Been Tested?**  
Tested in dev and production, ensuring each form of sorting worked without throwing errors or unintended side effects. 

**Checklist:**  
- [x] Testing of all relevent features completed (saving/loading lists, printing, etc)
- [x] No new warnings/errors added to project
      

